### PR TITLE
Better formatting

### DIFF
--- a/openvino_devtools/ovstat.py
+++ b/openvino_devtools/ovstat.py
@@ -59,9 +59,10 @@ def ovstat(path: str, obfuscate: bool):
     op_statistics(model, stat, obfuscate)
     keys = list(stat)
     keys.sort(key=lambda x: x[0] + x[2] + x[1])
+    format_len = len(str(max(stat.values(), key=lambda x: x[1])[1]))
     for key in keys:
         opstat = stat[key]
-        print(key[0] + ' ' + key[2] + ' : ' + key[1] + '\t' + str(opstat[1]))
+        print(f'{opstat[1]:{format_len}} {key[0]} {key[2]} : {key[1]}')
 
 
 def parse_arguments():

--- a/openvino_devtools/ovstat.py
+++ b/openvino_devtools/ovstat.py
@@ -62,7 +62,7 @@ def ovstat(path: str, obfuscate: bool):
     format_len = len(str(max(stat.values(), key=lambda x: x[1])[1]))
     for key in keys:
         opstat = stat[key]
-        print(f'{opstat[1]:{format_len}} {key[0]} {key[2]} : {key[1]}')
+        print(f'{opstat[1]:{format_len}}\t{key[0]} {key[2]} : {key[1]}')
 
 
 def parse_arguments():


### PR DESCRIPTION
Moved the number of operations to the left and aligned formatting across all ops:
![{F3E58F31-3C13-4021-AA09-DB528D10BD04}](https://github.com/user-attachments/assets/285cdd55-9133-430c-8eee-b20355cea3a9)
